### PR TITLE
Fixes

### DIFF
--- a/gatling/gatling_script.scala
+++ b/gatling/gatling_script.scala
@@ -287,7 +287,7 @@ import org.apache.http.client.entity.UrlEncodedFormEntity
 			//duration that took the package to send all the messages
 			duration(sensorIndex)=endTimePackage(sensorIndex)-startTimePackage(sensorIndex)
 			//Put parameters in session for next synthesis request
-			session.set("paramDuration", ""+(duration(sensorIndex)/1000).toInt).set("paramTimestamp", java.net.URLEncoder.encode(formatter.format(startTimePackage(sensorIndex)), "utf-8"))
+			session.set("paramDuration", ""+(duration(sensorIndex)/1000).toInt).set("paramTimestamp", formatter.format(startTimePackage(sensorIndex)))
 			})
 			//call and get the synthesis corresponding to the duration and timestamp
 			.exec(http(synthesisResultsCheck(sensorIndex))
@@ -399,7 +399,7 @@ import org.apache.http.client.entity.UrlEncodedFormEntity
 		
 		//this is the url of the synthesis get method that sends a synthesis object containing 10 sensor types results
   		val urlSyhtesis = "http://192.168.1.1/messages/synthesis?timestamp="
-  						.concat(java.net.URLEncoder.encode(formatter.format(simulationStartTimeMs), "utf-8"))
+  						.concat(formatter.format(simulationStartTimeMs))
   						.concat("&duration=")
   						.concat(""+((timeOfSimulation/1000000000)+1).toInt)
   						


### PR DESCRIPTION
Je n'ai pas réussi à conserver les sauts de ligne...
- paramétrage de l'ip au début
- utilisation de DateTimeFormatter (thread safe, ISO)
- typage des nombres en Long (j'ai oublié le tableau duration...)
- ajout de 1s à la duration (problème d'arrondi inférieur)
- comparaisons basées sur des BigDecimal
- affichage de l'erreur avant la sortie exit(0)
- encodage du paramètre timestamp dans la requête finale

Il aurait pu être mieux d'utiliser le async http client pour les requêtes HTTP spécifique, c'est celui utilisé par Gatling.
